### PR TITLE
Add button to open menu & Also set visibility to collapsed when not open.

### DIFF
--- a/RadialMenu/Themes/RadialMenu.xaml
+++ b/RadialMenu/Themes/RadialMenu.xaml
@@ -6,8 +6,11 @@
     <Style TargetType="{x:Type Controls:RadialMenu}">
 
         <Style.Triggers>
+			<Trigger Property="IsOpen" Value="False">
+				<Setter Property="Visibility" Value="Collapsed" />
+			</Trigger>
             <Trigger Property="IsOpen" Value="True">
-
+				<Setter Property="Visibility" Value="Visible" />
                 <!-- RadialMenu openning animation -->
                 <Trigger.EnterActions>
                     <BeginStoryboard>

--- a/RadialMenuDemo/MainWindow.xaml
+++ b/RadialMenuDemo/MainWindow.xaml
@@ -11,6 +11,7 @@
     </Window.Resources>
 
     <Grid>
+		<Button Content="Open Menu" HorizontalAlignment="Center" VerticalAlignment="Center" Padding="10" Command="{Binding OpenRadialMenu}" />		
         <RadialMenu:RadialMenu IsOpen="{Binding IsOpen}">
 
             <RadialMenu:RadialMenu.CentralItem>
@@ -102,7 +103,6 @@
             </RadialMenu:RadialMenuItem>
 
         </RadialMenu:RadialMenu>
-		<Button Content="Open Menu" HorizontalAlignment="Left" VerticalAlignment="Top" Padding="10" Command="{Binding OpenRadialMenu}" />
     </Grid>
 
 </Window>

--- a/RadialMenuDemo/MainWindow.xaml
+++ b/RadialMenuDemo/MainWindow.xaml
@@ -102,6 +102,7 @@
             </RadialMenu:RadialMenuItem>
 
         </RadialMenu:RadialMenu>
+		<Button Content="Open Menu" HorizontalAlignment="Left" VerticalAlignment="Top" Padding="10" Command="{Binding OpenRadialMenu}" />
     </Grid>
 
 </Window>


### PR DESCRIPTION
so you don't have to know to right click (otherwise maybe a textblock telling someone to right click).
A second commit Set visibility to collapsed when not open so items behind it in the menu are actionable and also prevent the non-showing buttons of the radial dial from stealing keyboard focus

Sorry for one PR for both.
