### PR TITLE
Set default visibility collapsed

### DIFF
--- a/RadialMenu/Themes/RadialMenu.xaml
+++ b/RadialMenu/Themes/RadialMenu.xaml
@@ -59,6 +59,7 @@
 
         <!-- Default RadialMenu style (while closed) -->
         <Setter Property="Opacity" Value="0"/>
+		<Setter Property="Visibility" Value="Collapsed"/>
         <Setter Property="Height" Value="300"/>
         <Setter Property="Width" Value="300"/>
         <Setter Property="RenderTransform">

--- a/RadialMenu/Themes/RadialMenu.xaml
+++ b/RadialMenu/Themes/RadialMenu.xaml
@@ -59,7 +59,7 @@
 
         <!-- Default RadialMenu style (while closed) -->
         <Setter Property="Opacity" Value="0"/>
-		<Setter Property="Visibility" Value="Collapsed"/>
+        <Setter Property="Visibility" Value="Collapsed"/>
         <Setter Property="Height" Value="300"/>
         <Setter Property="Width" Value="300"/>
         <Setter Property="RenderTransform">


### PR DESCRIPTION
As the code right now uses the IsOpen=true animation by default it will not be in a collapsed state even though its not visible. After the first open it is fine, but not before.  This changes that.
