### PR TITLE
Disable the control during the load/unload animation to prevent accident...

### DIFF
--- a/RadialMenu/Themes/RadialMenu.xaml
+++ b/RadialMenu/Themes/RadialMenu.xaml
@@ -27,10 +27,10 @@
                             <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Visibility">
                                 <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
                             </ObjectAnimationUsingKeyFrames>
-							<BooleanAnimationUsingKeyFrames Storyboard.TargetProperty="IsEnabled" Duration="0:0:0.5" FillBehavior="HoldEnd">
-								<DiscreteBooleanKeyFrame Value="False" KeyTime="0:0:0" />
-								<DiscreteBooleanKeyFrame Value="True" KeyTime="0:0:0.5" />
-							</BooleanAnimationUsingKeyFrames>
+                            <BooleanAnimationUsingKeyFrames Storyboard.TargetProperty="IsEnabled" Duration="0:0:0.5" FillBehavior="HoldEnd">
+                                <DiscreteBooleanKeyFrame Value="False" KeyTime="0:0:0" />
+                                <DiscreteBooleanKeyFrame Value="True" KeyTime="0:0:0.5" />
+                            </BooleanAnimationUsingKeyFrames>
 
                         </Storyboard>
                     </BeginStoryboard>
@@ -55,10 +55,10 @@
                             <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Visibility">
                                 <DiscreteObjectKeyFrame KeyTime="0:0:0.4" Value="{x:Static Visibility.Collapsed}"/>
                             </ObjectAnimationUsingKeyFrames>
-							<BooleanAnimationUsingKeyFrames Storyboard.TargetProperty="IsEnabled" Duration="0:0:0" FillBehavior="HoldEnd">
-								<DiscreteBooleanKeyFrame Value="False" KeyTime="0:0:0" />
-							</BooleanAnimationUsingKeyFrames>
-							
+                            <BooleanAnimationUsingKeyFrames Storyboard.TargetProperty="IsEnabled" Duration="0:0:0" FillBehavior="HoldEnd">
+                                <DiscreteBooleanKeyFrame Value="False" KeyTime="0:0:0" />
+                            </BooleanAnimationUsingKeyFrames>
+                            
                         </Storyboard>
                     </BeginStoryboard>
                 </Trigger.ExitActions>

--- a/RadialMenu/Themes/RadialMenu.xaml
+++ b/RadialMenu/Themes/RadialMenu.xaml
@@ -27,6 +27,11 @@
                             <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Visibility">
                                 <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="{x:Static Visibility.Visible}"/>
                             </ObjectAnimationUsingKeyFrames>
+							<BooleanAnimationUsingKeyFrames Storyboard.TargetProperty="IsEnabled" Duration="0:0:0.5" FillBehavior="HoldEnd">
+								<DiscreteBooleanKeyFrame Value="False" KeyTime="0:0:0" />
+								<DiscreteBooleanKeyFrame Value="True" KeyTime="0:0:0.5" />
+							</BooleanAnimationUsingKeyFrames>
+
                         </Storyboard>
                     </BeginStoryboard>
                 </Trigger.EnterActions>
@@ -50,6 +55,10 @@
                             <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Visibility">
                                 <DiscreteObjectKeyFrame KeyTime="0:0:0.4" Value="{x:Static Visibility.Collapsed}"/>
                             </ObjectAnimationUsingKeyFrames>
+							<BooleanAnimationUsingKeyFrames Storyboard.TargetProperty="IsEnabled" Duration="0:0:0" FillBehavior="HoldEnd">
+								<DiscreteBooleanKeyFrame Value="False" KeyTime="0:0:0" />
+							</BooleanAnimationUsingKeyFrames>
+							
                         </Storyboard>
                     </BeginStoryboard>
                 </Trigger.ExitActions>


### PR DESCRIPTION
...al clicks

For some reason just setting the property to false using a setter on IsOpen=False doesn't work so used a one frame animation there.

If the user is using a touch device its probably best to do something like this so a double tap doesn't trigger multiple events.
